### PR TITLE
feat: fix websocket events

### DIFF
--- a/src/backend/app/routes/http/reverse.py
+++ b/src/backend/app/routes/http/reverse.py
@@ -131,6 +131,19 @@ async def upload_file_to_room(
     # observers can see in-flight uploads (mirrors upload.py behavior).
     await UploadProgress.start(upload_key=file_key, filename=filename)
 
+    # Broadcast upload start to the room
+    await RoomState.publish_event(
+        room_id,
+        json.dumps(
+            {
+                "type": "upload_start",
+                "upload_key": file_key,
+                "filename": filename,
+                "size": file.size if file.size is not None else 0,
+            }
+        ),
+    )
+
     # Multipart upload to RustFS
     # Store filename in S3 metadata so the shareable download link works
     # even after the room expires.
@@ -145,6 +158,8 @@ async def upload_file_to_room(
     parts: list[CompletedPartTypeDef] = []
     part_number = 1
     uploaded_size = 0
+    last_broadcast_size = 0
+    BROADCAST_THRESHOLD = ByteSize(kb=512).total_bytes()
 
     try:
         while True:
@@ -172,6 +187,20 @@ async def upload_file_to_room(
                 upload_key=file_key, uploaded_bytes=uploaded_size
             )
 
+            # Broadcast progress to the room (throttled)
+            if uploaded_size - last_broadcast_size >= BROADCAST_THRESHOLD:
+                await RoomState.publish_event(
+                    room_id,
+                    json.dumps(
+                        {
+                            "type": "upload_progress",
+                            "upload_key": file_key,
+                            "uploaded_bytes": uploaded_size,
+                        }
+                    ),
+                )
+                last_broadcast_size = uploaded_size
+
             # If the client disconnected mid-upload, abort and evict
             if await request.is_disconnected():
                 await s3.abort_multipart_upload(
@@ -180,6 +209,10 @@ async def upload_file_to_room(
                     UploadId=upload_id,
                 )
                 await UploadProgress.cancel(upload_key=file_key)
+                await RoomState.publish_event(
+                    room_id,
+                    json.dumps({"type": "upload_cancelled", "upload_key": file_key}),
+                )
                 raise HTTPException(status_code=499, detail="Client disconnected")
 
         if not parts:
@@ -195,9 +228,24 @@ async def upload_file_to_room(
             MultipartUpload={"Parts": parts},
         )
         await UploadProgress.finish(upload_key=file_key, final_size=uploaded_size)
+        # Broadcast final progress
+        await RoomState.publish_event(
+            room_id,
+            json.dumps(
+                {
+                    "type": "upload_progress",
+                    "upload_key": file_key,
+                    "uploaded_bytes": uploaded_size,
+                }
+            ),
+        )
     except HTTPException:
         # Ensure failed uploads are removed from AppState
         await UploadProgress.cancel(upload_key=file_key)
+        await RoomState.publish_event(
+            room_id,
+            json.dumps({"type": "upload_cancelled", "upload_key": file_key}),
+        )
         raise
     except Exception:
         await s3.abort_multipart_upload(
@@ -207,6 +255,10 @@ async def upload_file_to_room(
         )
         # Ensure failed uploads are removed from AppState
         await UploadProgress.cancel(upload_key=file_key)
+        await RoomState.publish_event(
+            room_id,
+            json.dumps({"type": "upload_cancelled", "upload_key": file_key}),
+        )
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Upload failed",

--- a/src/backend/app/routes/ws/reverse.py
+++ b/src/backend/app/routes/ws/reverse.py
@@ -149,6 +149,11 @@ async def room_ws(
                         await ws.send_text(json.dumps(data))
                     continue
 
+                if msg_type in ("upload_start", "upload_progress", "upload_cancelled"):
+                    async with send_lock:
+                        await ws.send_text(json.dumps(data))
+                    continue
+
                 try:
                     event = RoomFileEvent.model_validate(data)
                 except Exception:
@@ -156,6 +161,17 @@ async def room_ws(
                     continue
 
                 if event.event == "file_added":
+                    # Notify frontend about the new file entry
+                    async with send_lock:
+                        await ws.send_text(
+                            json.dumps(
+                                {
+                                    "type": "file_added",
+                                    "file": event.file.model_dump(mode="json"),
+                                }
+                            )
+                        )
+
                     if event.file.key in seen_keys:
                         continue
                     seen_keys.add(event.file.key)

--- a/src/frontend/src/routes/(needs_onboarding)/(navbar_and_footer)/reverse/[room_id]/+page.svelte
+++ b/src/frontend/src/routes/(needs_onboarding)/(navbar_and_footer)/reverse/[room_id]/+page.svelte
@@ -78,6 +78,14 @@
 		objectUrl?: string;
 	}
 
+	interface RemoteUpload {
+		key: string;
+		filename: string;
+		size: number;
+		uploadedBytes: number;
+		progress: Tween<number>;
+	}
+
 	let room_id = $derived(page.params.room_id);
 
 	function fileDownloadUrl(fileKey: string): string {
@@ -117,6 +125,7 @@
 	// WebSocket
 	let ws = $state<WebSocket | null>(null);
 	let wsConnected = $state(false);
+	let remoteUploads = $state<RemoteUpload[]>([]);
 
 	// Copy state
 	let copiedShareLink = $state(false);
@@ -205,6 +214,38 @@
 				hostCount = r.host_count ?? 1;
 			} else if (type === 'host_count') {
 				hostCount = msg.count as number;
+			} else if (type === 'upload_start') {
+				const key = msg.upload_key as string;
+				if (!remoteUploads.find((u) => u.key === key)) {
+					remoteUploads = [
+						...remoteUploads,
+						{
+							key,
+							filename: msg.filename as string,
+							size: msg.size as number,
+							uploadedBytes: 0,
+							progress: new Tween(0, { duration: 300, easing: cubicOut })
+						}
+					];
+				}
+			} else if (type === 'upload_progress') {
+				const key = msg.upload_key as string;
+				const bytes = msg.uploaded_bytes as number;
+				const upload = remoteUploads.find((u) => u.key === key);
+				if (upload) {
+					upload.uploadedBytes = bytes;
+					const pct = upload.size > 0 ? (bytes / upload.size) * 100 : 0;
+					upload.progress.target = pct;
+				}
+			} else if (type === 'upload_cancelled') {
+				const key = msg.upload_key as string;
+				remoteUploads = remoteUploads.filter((u) => u.key !== key);
+			} else if (type === 'file_added') {
+				const file = msg.file as RoomFileEntry;
+				if (!roomFiles.find((f) => f.key === file.key)) {
+					roomFiles = [...roomFiles, file];
+				}
+				remoteUploads = remoteUploads.filter((u) => u.key !== file.key);
 			} else if (type === 'file_start' && !isHost) {
 				receiveState = {
 					type: 'streaming',
@@ -670,6 +711,38 @@
 						{/if}
 					</Button>
 				</CardFooter>
+			</Card>
+		{/if}
+
+		<!-- Remote uploads (other hosts) -->
+		{#if remoteUploads.length > 0}
+			<Card>
+				<CardHeader>
+					<CardTitle class="flex items-center gap-2 text-base">
+						<Upload class="h-4 w-4" />
+						In-flight Uploads
+					</CardTitle>
+					<CardDescription>
+						Other hosts are currently uploading files to this room.
+					</CardDescription>
+				</CardHeader>
+				<CardContent class="space-y-4">
+					<div class="space-y-2">
+						{#each remoteUploads as u}
+							<div class="space-y-1 rounded-md border px-3 py-2">
+								<div class="flex items-center gap-2">
+									<FileIcon class="h-4 w-4 shrink-0 text-muted-foreground" />
+									<span class="min-w-0 flex-1 truncate text-sm">{u.filename}</span>
+									<span class="shrink-0 text-xs text-muted-foreground">
+										{formatFileSize(u.uploadedBytes)} / {formatFileSize(u.size)}
+									</span>
+									<LoaderCircle class="h-4 w-4 shrink-0 animate-spin text-muted-foreground" />
+								</div>
+								<Progress value={u.progress.current} max={100} class="h-1" />
+							</div>
+						{/each}
+					</div>
+				</CardContent>
 			</Card>
 		{/if}
 


### PR DESCRIPTION
  Backend
   - src/backend/app/routes/http/reverse.py: - Added broadcasting of upload_start when a file upload begins. - Added throttled upload_progress updates (every 512KB) to the room's WebSocket channel. - Added upload_cancelled broadcasting if an upload is aborted or fails. - Added a final upload_progress update upon successful completion.
   - src/backend/app/routes/ws/reverse.py:
       - Updated the WebSocket loop to relay upload_start, upload_progress, and upload_cancelled events to the frontend.
       - Added a file_added message type that is sent to the frontend whenever a new file is added to the room, ensuring all clients can update their lists in real-time.

  Frontend
   - src/frontend/src/routes/(needs_onboarding)/(navbar_and_footer)/reverse/[room_id]/+page.svelte: - Introduced remoteUploads state to track and display in-flight uploads from other hosts. - Updated the WebSocket onmessage handler to process all new upload and file events. - Added a new UI section "In-flight Uploads" that appears when other hosts are uploading, showing per-file progress bars. - Synchronized the "Available Files" / "Shared Files" list so that new entries appear immediately upon upload completion without requiring a page refresh. - Implemented deduplication to ensure files aren't added twice to the local state.