### PR TITLE
fix: redis not being initialized

### DIFF
--- a/src/backend/app/states/_global.py
+++ b/src/backend/app/states/_global.py
@@ -11,11 +11,15 @@ class GlobalState:
     def init_redis(cls) -> None:
         """Set the shared Redis client. Called once at startup."""
         redis_client = RedisClient.get()
-        cls._redis = redis_client
+        GlobalState._redis = redis_client
 
     @classmethod
     def _client(cls, redis_client: redis.Redis | None = None) -> redis.Redis:
-        return redis_client or cls._redis
+        if redis_client is not None:
+            return redis_client
+        if getattr(GlobalState, "_redis", None) is None:
+            GlobalState.init_redis()
+        return GlobalState._redis
 
     @classmethod
     async def _json_get(


### PR DESCRIPTION
Stack:

```python
[2026-04-25 08:03:03,411: WARNING/MainProcess] /app/.venv/lib/python3.14/site-packages/celery_aio_pool/__init__.py:30: UserWarning: Replacing Celery's default `build_tracer` utility w/ `build_async_tracer` from celery-aio-pool
  celery.app.trace.warn(


 -------------- celery@68fd7b56cbec v5.6.3 (recovery)
--- ***** -----
-- ******* ---- Linux-6.17.0-6-generic-x86_64-with-musl1 2026-04-25 08:03:03
- *** --- * ---
- ** ---------- [config]
- ** ---------- .> app:         app.celery:0x75d931579400
- ** ---------- .> transport:   redis://redis:6379/3
- ** ---------- .> results:     redis://redis:6379/0
- *** --- * --- .> concurrency: 1 (pool)
-- ******* ---- .> task events: OFF (enable -E to monitor tasks in this worker)
--- ***** -----
 -------------- [queues]
                .> celery           exchange=celery(direct) key=celery


[tasks]
  . app.tasks.clean_file.delete_expired_file

[2026-04-25 08:03:03,510: INFO/MainProcess] Connected to redis://redis:6379/3
[2026-04-25 08:03:03,515: INFO/MainProcess] mingle: searching for neighbors
[2026-04-25 08:03:04,540: INFO/MainProcess] mingle: all alone
[2026-04-25 08:03:04,595: INFO/MainProcess] celery@68fd7b56cbec ready.
[2026-04-25 08:07:06,038: INFO/MainProcess] Task app.tasks.clean_file.delete_expired_file[857386dc-f5ff-4362-9dff-6234efcf3779] received
[2026-04-25 08:07:06,153: INFO/MainProcess] select pg_catalog.version()
[2026-04-25 08:07:06,153: INFO/MainProcess] [raw sql] ()
2026-04-25 08:07:06,153 INFO sqlalchemy.engine.Engine select pg_catalog.version()
2026-04-25 08:07:06,153 INFO sqlalchemy.engine.Engine [raw sql] ()
2026-04-25 08:07:06,156 INFO sqlalchemy.engine.Engine select current_schema()
2026-04-25 08:07:06,156 INFO sqlalchemy.engine.Engine [raw sql] ()
[2026-04-25 08:07:06,156: INFO/MainProcess] select current_schema()
[2026-04-25 08:07:06,156: INFO/MainProcess] [raw sql] ()
2026-04-25 08:07:06,158 INFO sqlalchemy.engine.Engine show standard_conforming_strings
2026-04-25 08:07:06,158 INFO sqlalchemy.engine.Engine [raw sql] ()
[2026-04-25 08:07:06,158: INFO/MainProcess] show standard_conforming_strings
[2026-04-25 08:07:06,158: INFO/MainProcess] [raw sql] ()
2026-04-25 08:07:06,160 INFO sqlalchemy.engine.Engine BEGIN (implicit)
[2026-04-25 08:07:06,160: INFO/MainProcess] BEGIN (implicit)
[2026-04-25 08:07:06,170: INFO/MainProcess] SELECT file.key, file.id, file.filename, file.expires_at, file.expire_after_n_download, file.download_count, file.created_at, file.size
FROM file
WHERE file.id = $1::UUID OR file.download_count >= file.expire_after_n_download OR file.expires_at < $2::TIMESTAMP WITH TIME ZONE
2026-04-25 08:07:06,170 INFO sqlalchemy.engine.Engine SELECT file.key, file.id, file.filename, file.expires_at, file.expire_after_n_download, file.download_count, file.created_at, file.size
FROM file
WHERE file.id = $1::UUID OR file.download_count >= file.expire_after_n_download OR file.expires_at < $2::TIMESTAMP WITH TIME ZONE
[2026-04-25 08:07:06,170: INFO/MainProcess] [generated in 0.00041s] ('019dbe33-4972-7f10-91b3-340a97539ffe', datetime.datetime(2026, 4, 25, 8, 7, 6, 42905, tzinfo=datetime.timezone.utc))
2026-04-25 08:07:06,170 INFO sqlalchemy.engine.Engine [generated in 0.00041s] ('019dbe33-4972-7f10-91b3-340a97539ffe', datetime.datetime(2026, 4, 25, 8, 7, 6, 42905, tzinfo=datetime.timezone.utc))
2026-04-25 08:07:07,163 INFO sqlalchemy.engine.Engine DELETE FROM file WHERE file.id = $1::UUID
[2026-04-25 08:07:07,163: INFO/MainProcess] DELETE FROM file WHERE file.id = $1::UUID
2026-04-25 08:07:07,164 INFO sqlalchemy.engine.Engine [generated in 0.00040s] [(UUID('019d9c2a-b6e6-7ae0-b54a-f1a745dd8dff'),), (UUID('019db962-c572-760f-86ca-57d174f63b9b'),), (UUID('019db96b-9730-72b1-a64e-d761500e1b2f'),), (UUID('019db9ee-657b-7828-b9da-3570cba331b1'),), (UUID('019dbcbd-fc43-730b-913a-e02b836d878f'),), (UUID('019dbdb3-69a0-7073-bf4c-a1c54143a14f'),), (UUID('019dbe02-5d64-7273-847f-23b172be0eb3'),), (UUID('019dbe02-a118-7125-8172-8078fad48f0b'),), (UUID('019dbe33-4972-7f10-91b3-340a97539ffe'),)]
[2026-04-25 08:07:07,164: INFO/MainProcess] [generated in 0.00040s] [(UUID('019d9c2a-b6e6-7ae0-b54a-f1a745dd8dff'),), (UUID('019db962-c572-760f-86ca-57d174f63b9b'),), (UUID('019db96b-9730-72b1-a64e-d761500e1b2f'),), (UUID('019db9ee-657b-7828-b9da-3570cba331b1'),), (UUID('019dbcbd-fc43-730b-913a-e02b836d878f'),), (UUID('019dbdb3-69a0-7073-bf4c-a1c54143a14f'),), (UUID('019dbe02-5d64-7273-847f-23b172be0eb3'),), (UUID('019dbe02-a118-7125-8172-8078fad48f0b'),), (UUID('019dbe33-4972-7f10-91b3-340a97539ffe'),)]
2026-04-25 08:07:07,183 INFO sqlalchemy.engine.Engine COMMIT
[2026-04-25 08:07:07,183: INFO/MainProcess] COMMIT
[2026-04-25 08:07:07,186: ERROR/MainProcess] Task exception was never retrieved
future: <Task finished name='Task-11' coro=<on_file_delete.<locals>.do_evict() done, defined at /app/app/models/files.py:81> exception=AttributeError('_redis')>
Traceback (most recent call last):
  File "/app/app/models/files.py", line 82, in do_evict
    await AppState.evict_files(file_keys=[file_key], freed_bytes=file_size)
  File "/app/app/states/app.py", line 177, in evict_files
    current = await cls.get(redis_client=redis_client)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/app/states/app.py", line 156, in get
    data = await cls._json_get(settings.STATE_REDIS_KEY, redis_client=redis_client)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/app/states/_global.py", line 24, in _json_get
    raw = await cast(Awaitable[Any], cls._client(redis_client).json().get(key))
                                     ~~~~~~~~~~~^^^^^^^^^^^^^^
  File "/app/app/states/_global.py", line 18, in _client
    return redis_client or cls._redis
                           ^^^^^^^^^^
  File "/app/.venv/lib/python3.14/site-packages/pydantic/_internal/_model_construction.py", line 290, in __getattr__
    raise AttributeError(item)
AttributeError: _redis
[2026-04-25 08:07:07,205: ERROR/MainProcess] Task exception was never retrieved
future: <Task finished name='Task-12' coro=<on_file_delete.<locals>.do_evict() done, defined at /app/app/models/files.py:81> exception=AttributeError('_redis')>
Traceback (most recent call last):
  File "/app/app/models/files.py", line 82, in do_evict
    await AppState.evict_files(file_keys=[file_key], freed_bytes=file_size)
  File "/app/app/states/app.py", line 177, in evict_files
    current = await cls.get(redis_client=redis_client)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/app/states/app.py", line 156, in get
    data = await cls._json_get(settings.STATE_REDIS_KEY, redis_client=redis_client)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/app/states/_global.py", line 24, in _json_get
    raw = await cast(Awaitable[Any], cls._client(redis_client).json().get(key))
                                     ~~~~~~~~~~~^^^^^^^^^^^^^^
  File "/app/app/states/_global.py", line 18, in _client
    return redis_client or cls._redis
                           ^^^^^^^^^^
  File "/app/.venv/lib/python3.14/site-packages/pydantic/_internal/_model_construction.py", line 290, in __getattr__
    raise AttributeError(item)
AttributeError: _redis
[2026-04-25 08:07:07,207: ERROR/MainProcess] Task exception was never retrieved
future: <Task finished name='Task-13' coro=<on_file_delete.<locals>.do_evict() done, defined at /app/app/models/files.py:81> exception=AttributeError('_redis')>
Traceback (most recent call last):
  File "/app/app/models/files.py", line 82, in do_evict
    await AppState.evict_files(file_keys=[file_key], freed_bytes=file_size)
  File "/app/app/states/app.py", line 177, in evict_files
    current = await cls.get(redis_client=redis_client)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/app/states/app.py", line 156, in get
    data = await cls._json_get(settings.STATE_REDIS_KEY, redis_client=redis_client)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/app/states/_global.py", line 24, in _json_get
    raw = await cast(Awaitable[Any], cls._client(redis_client).json().get(key))
                                     ~~~~~~~~~~~^^^^^^^^^^^^^^
  File "/app/app/states/_global.py", line 18, in _client
    return redis_client or cls._redis
                           ^^^^^^^^^^
  File "/app/.venv/lib/python3.14/site-packages/pydantic/_internal/_model_construction.py", line 290, in __getattr__
    raise AttributeError(item)
AttributeError: _redis
[2026-04-25 08:07:07,209: ERROR/MainProcess] Task exception was never retrieved
future: <Task finished name='Task-14' coro=<on_file_delete.<locals>.do_evict() done, defined at /app/app/models/files.py:81> exception=AttributeError('_redis')>
Traceback (most recent call last):
  File "/app/app/models/files.py", line 82, in do_evict
    await AppState.evict_files(file_keys=[file_key], freed_bytes=file_size)
  File "/app/app/states/app.py", line 177, in evict_files
    current = await cls.get(redis_client=redis_client)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/app/states/app.py", line 156, in get
    data = await cls._json_get(settings.STATE_REDIS_KEY, redis_client=redis_client)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/app/states/_global.py", line 24, in _json_get
    raw = await cast(Awaitable[Any], cls._client(redis_client).json().get(key))
                                     ~~~~~~~~~~~^^^^^^^^^^^^^^
  File "/app/app/states/_global.py", line 18, in _client
    return redis_client or cls._redis
                           ^^^^^^^^^^
  File "/app/.venv/lib/python3.14/site-packages/pydantic/_internal/_model_construction.py", line 290, in __getattr__
    raise AttributeError(item)
AttributeError: _redis
[2026-04-25 08:07:07,211: ERROR/MainProcess] Task exception was never retrieved
future: <Task finished name='Task-15' coro=<on_file_delete.<locals>.do_evict() done, defined at /app/app/models/files.py:81> exception=AttributeError('_redis')>
Traceback (most recent call last):
  File "/app/app/models/files.py", line 82, in do_evict
    await AppState.evict_files(file_keys=[file_key], freed_bytes=file_size)
  File "/app/app/states/app.py", line 177, in evict_files
    current = await cls.get(redis_client=redis_client)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/app/states/app.py", line 156, in get
    data = await cls._json_get(settings.STATE_REDIS_KEY, redis_client=redis_client)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/app/states/_global.py", line 24, in _json_get
    raw = await cast(Awaitable[Any], cls._client(redis_client).json().get(key))
                                     ~~~~~~~~~~~^^^^^^^^^^^^^^
  File "/app/app/states/_global.py", line 18, in _client
    return redis_client or cls._redis
                           ^^^^^^^^^^
  File "/app/.venv/lib/python3.14/site-packages/pydantic/_internal/_model_construction.py", line 290, in __getattr__
    raise AttributeError(item)
AttributeError: _redis
[2026-04-25 08:07:07,213: ERROR/MainProcess] Task exception was never retrieved
future: <Task finished name='Task-16' coro=<on_file_delete.<locals>.do_evict() done, defined at /app/app/models/files.py:81> exception=AttributeError('_redis')>
Traceback (most recent call last):
  File "/app/app/models/files.py", line 82, in do_evict
    await AppState.evict_files(file_keys=[file_key], freed_bytes=file_size)
  File "/app/app/states/app.py", line 177, in evict_files
    current = await cls.get(redis_client=redis_client)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/app/states/app.py", line 156, in get
    data = await cls._json_get(settings.STATE_REDIS_KEY, redis_client=redis_client)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/app/states/_global.py", line 24, in _json_get
    raw = await cast(Awaitable[Any], cls._client(redis_client).json().get(key))
                                     ~~~~~~~~~~~^^^^^^^^^^^^^^
  File "/app/app/states/_global.py", line 18, in _client
    return redis_client or cls._redis
                           ^^^^^^^^^^
  File "/app/.venv/lib/python3.14/site-packages/pydantic/_internal/_model_construction.py", line 290, in __getattr__
    raise AttributeError(item)
AttributeError: _redis
[2026-04-25 08:07:07,214: ERROR/MainProcess] Task exception was never retrieved
future: <Task finished name='Task-17' coro=<on_file_delete.<locals>.do_evict() done, defined at /app/app/models/files.py:81> exception=AttributeError('_redis')>
Traceback (most recent call last):
  File "/app/app/models/files.py", line 82, in do_evict
    await AppState.evict_files(file_keys=[file_key], freed_bytes=file_size)
  File "/app/app/states/app.py", line 177, in evict_files
    current = await cls.get(redis_client=redis_client)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/app/states/app.py", line 156, in get
    data = await cls._json_get(settings.STATE_REDIS_KEY, redis_client=redis_client)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/app/states/_global.py", line 24, in _json_get
    raw = await cast(Awaitable[Any], cls._client(redis_client).json().get(key))
                                     ~~~~~~~~~~~^^^^^^^^^^^^^^
  File "/app/app/states/_global.py", line 18, in _client
    return redis_client or cls._redis
                           ^^^^^^^^^^
  File "/app/.venv/lib/python3.14/site-packages/pydantic/_internal/_model_construction.py", line 290, in __getattr__
    raise AttributeError(item)
AttributeError: _redis
[2026-04-25 08:07:07,216: ERROR/MainProcess] Task exception was never retrieved
future: <Task finished name='Task-18' coro=<on_file_delete.<locals>.do_evict() done, defined at /app/app/models/files.py:81> exception=AttributeError('_redis')>
Traceback (most recent call last):
  File "/app/app/models/files.py", line 82, in do_evict
    await AppState.evict_files(file_keys=[file_key], freed_bytes=file_size)
  File "/app/app/states/app.py", line 177, in evict_files
    current = await cls.get(redis_client=redis_client)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/app/states/app.py", line 156, in get
    data = await cls._json_get(settings.STATE_REDIS_KEY, redis_client=redis_client)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/app/states/_global.py", line 24, in _json_get
    raw = await cast(Awaitable[Any], cls._client(redis_client).json().get(key))
                                     ~~~~~~~~~~~^^^^^^^^^^^^^^
  File "/app/app/states/_global.py", line 18, in _client
    return redis_client or cls._redis
                           ^^^^^^^^^^
  File "/app/.venv/lib/python3.14/site-packages/pydantic/_internal/_model_construction.py", line 290, in __getattr__
    raise AttributeError(item)
AttributeError: _redis
[2026-04-25 08:07:07,218: ERROR/MainProcess] Task exception was never retrieved
future: <Task finished name='Task-19' coro=<on_file_delete.<locals>.do_evict() done, defined at /app/app/models/files.py:81> exception=AttributeError('_redis')>
Traceback (most recent call last):
  File "/app/app/models/files.py", line 82, in do_evict
    await AppState.evict_files(file_keys=[file_key], freed_bytes=file_size)
  File "/app/app/states/app.py", line 177, in evict_files
    current = await cls.get(redis_client=redis_client)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/app/states/app.py", line 156, in get
    data = await cls._json_get(settings.STATE_REDIS_KEY, redis_client=redis_client)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/app/states/_global.py", line 24, in _json_get
    raw = await cast(Awaitable[Any], cls._client(redis_client).json().get(key))
                                     ~~~~~~~~~~~^^^^^^^^^^^^^^
  File "/app/app/states/_global.py", line 18, in _client
    return redis_client or cls._redis
                           ^^^^^^^^^^
  File "/app/.venv/lib/python3.14/site-packages/pydantic/_internal/_model_construction.py", line 290, in __getattr__
    raise AttributeError(item)
AttributeError: _redis
[2026-04-25 08:07:07,245: INFO/MainProcess] Task app.tasks.clean_file.delete_expired_file[857386dc-f5ff-4362-9dff-6234efcf3779] succeeded in 1.2045057129998895s: 'Processed 9 deletions.'
```

